### PR TITLE
Swift4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode9
 install:
  - gem install xcpretty
 script:

--- a/Examples/Swift/arguments_example/main.swift
+++ b/Examples/Swift/arguments_example/main.swift
@@ -8,25 +8,24 @@
 
 import Docopt
 
-let doc : String = "Usage: arguments_example.py [-vqrh] [FILE] ... \n" +
-"          arguments_example.py (--left | --right) CORRECTION FILE\n" +
-"\n" +
-"Process FILE and optionally apply correction to either left-hand side or\n" +
-"right-hand side.\n" +
-"\n" +
-"Arguments:\n" +
-"  FILE        optional input file\n" +
-"  CORRECTION  correction angle, needs FILE, --left or --right to be present\n" +
-"\n" +
-"Options:\n" +
-"  -h --help\n" +
-"  -v       verbose mode\n" +
-"  -q       quiet mode\n" +
-"  -r       make report\n" +
-"  --left   use left-hand side\n" +
-"  --right  use right-hand side\n"
+let doc : String = """
+Usage: arguments_example [-vqrh] [FILE] ...
+arguments_example (--left | --right) CORRECTION FILE
+Process FILE and optionally apply correction to either left-hand side or
+right-hand side.
+Arguments:
+FILE        optional input file
+CORRECTION  correction angle, needs FILE, --left or --right to be present
+Options:
+-h --help
+-v       verbose mode
+-q       quiet mode
+-r       make report
+--left   use left-hand side
+--right  use right-hand side
+"""
 
-var args = Process.arguments
-args.removeAtIndex(0) // arguments[0] is always the program_name
+var args = CommandLine.arguments
+_ = args.remove(at: 0) // arguments[0] is always the program_name
 let result = Docopt.parse(doc, argv: args, help: true, version: "1.0")
 print("Docopt result: \(result)")

--- a/Examples/Swift/calculator_example/main.swift
+++ b/Examples/Swift/calculator_example/main.swift
@@ -8,21 +8,21 @@
 
 import Docopt
 
-let doc : String = "Not a serious example.\n" +
-"\n" +
-"Usage:\n" +
-"  calculator_example.py <value> ( ( + | - | * | / ) <value> )...\n" +
-"  calculator_example.py <function> <value> [( , <value> )]...\n" +
-"  calculator_example.py (-h | --help)\n" +
-"\n" +
-"Examples:\n" +
-"  calculator_example.py 1 + 2 + 3 + 4 + 5\n" +
-"  calculator_example.py 1 + 2 '*' 3 / 4 - 5    # note quotes around '*'\n" +
-"  calculator_example.py sum 10 , 20 , 30 , 40\n" +
-"Options:\n" +
-"  -h, --help\n"
+let doc : String = """
+Not a serious example.
+Usage:
+calculator_example <value> ( ( + | - | * | / ) <value> )...
+calculator_example <function> <value> [( , <value> )]...
+calculator_example (-h | --help)
+Examples:
+calculator_example 1 + 2 + 3 + 4 + 5
+calculator_example 1 + 2 '*' 3 / 4 - 5    # note quotes around '*'
+calculator_example sum 10 , 20 , 30 , 40
+Options:
+-h, --help
+"""
 
-var args = Process.arguments
-args.removeAtIndex(0) // arguments[0] is always the program_name
+var args = CommandLine.arguments
+_ = args.remove(at: 0) // arguments[0] is always the program_name
 let result = Docopt.parse(doc, argv: args, help: true, version: "1.0")
 print("Docopt result: \(result)")

--- a/Examples/Swift/naval_fate/main.swift
+++ b/Examples/Swift/naval_fate/main.swift
@@ -8,24 +8,24 @@
 
 import Docopt
 
-let doc : String = "Naval Fate.\n" +
-"\n" +
-"Usage:\n" +
-"  naval_fate.py ship new <name>...\n" +
-"  naval_fate.py ship <name> move <x> <y> [--speed=<kn>]\n" +
-"  naval_fate.py ship shoot <x> <y>\n" +
-"  naval_fate.py mine (set|remove) <x> <y> [--moored|--drifting]\n" +
-"  naval_fate.py -h | --help\n" +
-"  naval_fate.py --version\n" +
-"\n" +
-"Options:\n" +
-"  -h --help     Show this screen.\n" +
-"  --version     Show version.\n" +
-"  --speed=<kn>  Speed in knots [default: 10].\n" +
-"  --moored      Moored (anchored) mine.\n" +
-"  --drifting    Drifting mine.\n"
+let doc : String = """
+Naval Fate.
+Usage:
+naval_fate ship new <name>...
+naval_fate ship <name> move <x> <y> [--speed=<kn>]
+naval_fate ship shoot <x> <y>
+naval_fate mine (set|remove) <x> <y> [--moored|--drifting]
+naval_fate -h | --help
+naval_fate --version
+Options:
+-h --help     Show this screen.
+--version     Show version.
+--speed=<kn>  Speed in knots [default: 10].
+--moored      Moored (anchored) mine.
+--drifting    Drifting mine.
+"""
 
-var args = Process.arguments
-args.removeAtIndex(0) // arguments[0] is always the program_name
+var args = CommandLine.arguments
+_ = args.remove(at: 0) // arguments[0] is always the program_name
 let result = Docopt.parse(doc, argv: args, help: true, version: "1.0")
 print("Docopt result: \(result)")

--- a/Sources/BranchPattern.swift
+++ b/Sources/BranchPattern.swift
@@ -38,7 +38,7 @@ internal class BranchPattern : Pattern {
         }
     }
     
-    override func flat<T: Pattern>(_ type: T.Type) -> [T] {
+    override func flat<T: Pattern>(_: T.Type) -> [T] {
         if type(of: self) === T.self {
             return [self as! T]
         }

--- a/Sources/Docopt.swift
+++ b/Sources/Docopt.swift
@@ -18,7 +18,7 @@ open class Docopt : NSObject {
     fileprivate let optionsFirst: Bool
     fileprivate let arguments: [String]
     
-    open static func parse(_ doc: String, argv: [String], help: Bool = false, version: String? = nil, optionsFirst: Bool = false) -> [String: AnyObject] {
+    @objc open static func parse(_ doc: String, argv: [String], help: Bool = false, version: String? = nil, optionsFirst: Bool = false) -> [String: AnyObject] {
         return Docopt(doc, argv: argv, help: help, version: version, optionsFirst: optionsFirst).result
     }
     

--- a/Sources/String.swift
+++ b/Sources/String.swift
@@ -81,7 +81,7 @@ internal extension String {
     }
     
     subscript(range: Range<Int>) -> String {
-        return self[characters.index(startIndex, offsetBy: range.lowerBound)..<characters.index(startIndex, offsetBy: range.upperBound)]
+      return String(self[characters.index(startIndex, offsetBy: range.lowerBound)..<characters.index(startIndex, offsetBy: range.upperBound)])
     }
 
     subscript(range: NSRange) -> String {

--- a/Tests/objc/NMBExceptionCapture.h
+++ b/Tests/objc/NMBExceptionCapture.h
@@ -2,7 +2,7 @@
 
 @interface NMBExceptionCapture : NSObject
 
-- (id)initWithHandler:(void(^)(NSException *))handler finally:(void(^)())finally;
-- (void)tryBlock:(void(^)())unsafeBlock;
+- (id)initWithHandler:(void(^)(NSException *))handler finally:(void(^)(void))finally;
+- (void)tryBlock:(void(^)(void))unsafeBlock;
 
 @end

--- a/Tests/objc/NMBExceptionCapture.m
+++ b/Tests/objc/NMBExceptionCapture.m
@@ -2,12 +2,12 @@
 
 @interface NMBExceptionCapture ()
 @property (nonatomic, copy) void(^handler)(NSException *exception);
-@property (nonatomic, copy) void(^finally)();
+@property (nonatomic, copy) void(^finally)(void);
 @end
 
 @implementation NMBExceptionCapture
 
-- (id)initWithHandler:(void(^)(NSException *))handler finally:(void(^)())finally {
+- (id)initWithHandler:(void(^)(NSException *))handler finally:(void(^)(void))finally {
     self = [super init];
     if (self) {
         self.handler = handler;
@@ -16,7 +16,7 @@
     return self;
 }
 
-- (void)tryBlock:(void(^)())unsafeBlock {
+- (void)tryBlock:(void(^)(void))unsafeBlock {
     @try {
         unsafeBlock();
     }

--- a/docopt.xcodeproj/project.pbxproj
+++ b/docopt.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -73,6 +73,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3CE9112D1AA1DE7D00082C0B;
 			remoteInfo = docopt;
+		};
+		6A85674A1EF01F19001F7250 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CE911251AA1DE7D00082C0B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CE9112D1AA1DE7D00082C0B;
+			remoteInfo = Docopt;
+		};
+		6A85674C1EF01F33001F7250 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CE911251AA1DE7D00082C0B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CE9112D1AA1DE7D00082C0B;
+			remoteInfo = Docopt;
+		};
+		6AE08CDC1EEA0AAA00C3E66B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CE911251AA1DE7D00082C0B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CE9112D1AA1DE7D00082C0B;
+			remoteInfo = Docopt;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -395,6 +416,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6AE08CDD1EEA0AAA00C3E66B /* PBXTargetDependency */,
 			);
 			name = arguments_example_swift;
 			productName = arguments_example_swift;
@@ -412,6 +434,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6A85674D1EF01F33001F7250 /* PBXTargetDependency */,
 			);
 			name = naval_fate_swift;
 			productName = naval_fate_swift;
@@ -483,6 +506,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6A85674B1EF01F19001F7250 /* PBXTargetDependency */,
 			);
 			name = calculator_example_swift;
 			productName = calculator_example_swift;
@@ -533,11 +557,12 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = kovpas;
 				TargetAttributes = {
 					3C29E4531AAE380500B75022 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0900;
 					};
 					3C29E46E1AAE394F00B75022 = {
 						CreatedOnToolsVersion = 6.3;
@@ -547,7 +572,7 @@
 					};
 					3C4CA30D1AA9045B00027F0F = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0900;
 					};
 					3C4CA3241AA905BD00027F0F = {
 						CreatedOnToolsVersion = 6.3;
@@ -557,15 +582,16 @@
 					};
 					3CE9112D1AA1DE7D00082C0B = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0900;
 					};
 					3CE911381AA1DE7E00082C0B = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0900;
 					};
 				};
 			};
 			buildConfigurationList = 3CE911281AA1DE7D00082C0B /* Build configuration list for PBXProject "docopt" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -712,6 +738,21 @@
 			target = 3CE9112D1AA1DE7D00082C0B /* Docopt */;
 			targetProxy = 3CE9113B1AA1DE7E00082C0B /* PBXContainerItemProxy */;
 		};
+		6A85674B1EF01F19001F7250 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CE9112D1AA1DE7D00082C0B /* Docopt */;
+			targetProxy = 6A85674A1EF01F19001F7250 /* PBXContainerItemProxy */;
+		};
+		6A85674D1EF01F33001F7250 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CE9112D1AA1DE7D00082C0B /* Docopt */;
+			targetProxy = 6A85674C1EF01F33001F7250 /* PBXContainerItemProxy */;
+		};
+		6AE08CDD1EEA0AAA00C3E66B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CE9112D1AA1DE7D00082C0B /* Docopt */;
+			targetProxy = 6AE08CDC1EEA0AAA00C3E66B /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -722,10 +763,11 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -733,10 +775,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -750,9 +793,10 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -762,8 +806,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -774,8 +819,10 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				LD_RUNPATH_SEARCH_PATHS = ". @loader_path";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -783,8 +830,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				LD_RUNPATH_SEARCH_PATHS = ". @loader_path";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -795,10 +844,10 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				LD_RUNPATH_SEARCH_PATHS = .;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -806,10 +855,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				LD_RUNPATH_SEARCH_PATHS = .;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -820,9 +869,10 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				LD_RUNPATH_SEARCH_PATHS = .;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -830,9 +880,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				LD_RUNPATH_SEARCH_PATHS = .;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -843,10 +894,11 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -854,10 +906,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -867,13 +920,21 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -881,6 +942,12 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(SRCROOT)/**",
+				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -894,12 +961,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -911,13 +976,21 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -925,17 +998,23 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(SRCROOT)/**",
+				);
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = fast;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -944,14 +1023,28 @@
 		3CE911451AA1DE7E00082C0B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_VERSION = A;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks";
@@ -959,20 +1052,36 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
 		3CE911461AA1DE7E00082C0B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_VERSION = A;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks";
@@ -980,6 +1089,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1000,6 +1111,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = Tests/DocoptTests.h;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1016,6 +1128,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = Tests/DocoptTests.h;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/docopt.xcodeproj/xcshareddata/xcschemes/Docopt.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/Docopt.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/docopt.xcodeproj/xcshareddata/xcschemes/arguments_example.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/arguments_example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/docopt.xcodeproj/xcshareddata/xcschemes/arguments_example_swift.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/arguments_example_swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/docopt.xcodeproj/xcshareddata/xcschemes/calculator_example.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/calculator_example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/docopt.xcodeproj/xcshareddata/xcschemes/calculator_example_swift.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/calculator_example_swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/docopt.xcodeproj/xcshareddata/xcschemes/naval_fate.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/naval_fate.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/docopt.xcodeproj/xcshareddata/xcschemes/naval_fate_swift.xcscheme
+++ b/docopt.xcodeproj/xcshareddata/xcschemes/naval_fate_swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Obviously a swift 4 conversion isn't done until it's officially released, along with the xcode that bundles it. But for now, this is a working version for the current xcode9 and swift4 snapshot on MacOS 10.13 (as xcode9 doesn't include a 10.12 SDK).

As an aside, 10.13 doesn't currently wake from sleep and many machines can't boot from APFS even though it embeds an EFI driver right in the filesystem. Take necessary precautions (and backups) before installing it _anywhere_. I did not see if everything worked as it should using xcodelegacy to install older SDKs into newer xcode versions... Though you would also have to manually install swift4 snapshots to use in this case, as the xcode bundled version is compiled against 10.13. 

The most exciting highlight here, for me, you can see in the new examples. God, those sweet sexy multi-line string literals. Perfection. 