### PR TITLE
Define library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "Docopt",
+    products: [
+      .library(name: "Docopt", targets: ["Docopt"])
+    ],
     targets: [
         .target(
             name: "Docopt",


### PR DESCRIPTION
Without defining a product it's not possible to link/import this in a SPM project.

Fixes #9.