### PR TITLE
Re-enable the tests under SwiftPM.

### DIFF
--- a/DocoptTests/DocoptTestCasesTests.swift
+++ b/DocoptTests/DocoptTestCasesTests.swift
@@ -61,7 +61,18 @@ class DocoptTestCasesTests: XCTestCase {
     
     private func fixturesFilePath() -> String? {
         let testBundle: Bundle = Bundle(for: type(of: self))
-        return testBundle.path(forResource: "testcases", ofType: "docopt")
+        guard let path = testBundle.path(forResource: "testcases", ofType: "docopt") else {
+            // SwiftPM currently doesn't support bundles, so if the tests are run with it,
+            // we'll fail to find the bundle path here.
+            // As a temporary workaround, we can fall back on a relative path. This is fragile
+            // as it relies on the assumption that we know where SwiftPM will put the
+            // executable, and where the testcases file lives relative to it, but it's
+            // better than just disabling all the tests...
+            let url = testBundle.bundleURL.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("DocoptTests").appendingPathComponent("testcases.docopt")
+            return url.path
+        }
+        
+        return path
     }
     
     private func fixturesFileContents() -> String {

--- a/DocoptTests/DocoptTestCasesTests.swift
+++ b/DocoptTests/DocoptTestCasesTests.swift
@@ -23,15 +23,15 @@ class DocoptTestCasesTests: XCTestCase {
             XCTAssertTrue(exists, "Fixtures file testcases.docopt does not exist in testing bundle")
         }
     }
-    
+
     func testFixturesFileCanBeOpened() {
         XCTAssertNotEqual(fixturesFileContents(), "", "Could not read fixtures file")
     }
-    
+
     func testTestCases() {
         let rawTestCases = fixturesFileContents()
         let parser = DocoptTestCaseParser(rawTestCases)
-        
+
         for testCase in parser.testCases {
             let expectedOutput: AnyObject = testCase.expectedOutput
             var result: AnyObject = "user-error" as AnyObject
@@ -58,23 +58,26 @@ class DocoptTestCasesTests: XCTestCase {
             }
         }
     }
-    
+
+    private func fallbackFilePath(from exeURL : URL) -> String? {
+        // SwiftPM currently doesn't support building bundles, so if the tests are run
+        // with SwiftPM we'll fail to find the bundle path here.
+        // As a temporary workaround, we can fall back on a relative path from the executable.
+        // This is fragile as it relies on the assumption that we know where SwiftPM will
+        // put the build products, and where the testcases file lives relative to them,
+        // but it's better than just disabling all the tests...
+        let path = exeURL.appendingPathComponent("../../../../Tests/DocoptTests/testcases.docopt").standardized.path
+        return path
+    }
+
     private func fixturesFilePath() -> String? {
         let testBundle: Bundle = Bundle(for: type(of: self))
         guard let path = testBundle.path(forResource: "testcases", ofType: "docopt") else {
-            // SwiftPM currently doesn't support bundles, so if the tests are run with it,
-            // we'll fail to find the bundle path here.
-            // As a temporary workaround, we can fall back on a relative path. This is fragile
-            // as it relies on the assumption that we know where SwiftPM will put the
-            // executable, and where the testcases file lives relative to it, but it's
-            // better than just disabling all the tests...
-            let url = testBundle.bundleURL.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("DocoptTests").appendingPathComponent("testcases.docopt")
-            return url.path
+            return fallbackFilePath(from: testBundle.bundleURL)
         }
-        
         return path
     }
-    
+
     private func fixturesFileContents() -> String {
         if let filePath = self.fixturesFilePath() {
             let fileContents = try! String(contentsOfFile: filePath, encoding: String.Encoding.utf8)

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,12 @@ let package = Package(
             name: "Docopt",
             path: "Sources"
         )
-        // Commented out until SPM supports resources
-        //, 
-        // .testTarget(
-        //     name: "DocoptTests",
-        //     dependencies: ["Docopt"],
-        //     path: "DocoptTests"
-        // )
+//         Commented out until SPM supports resources
+        ,
+         .testTarget(
+             name: "DocoptTests",
+             dependencies: ["Docopt"],
+             path: "DocoptTests"
+         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,7 @@ let package = Package(
         .target(
             name: "Docopt",
             path: "Sources"
-        )
-//         Commented out until SPM supports resources
-        ,
+        ),
          .testTarget(
              name: "DocoptTests",
              dependencies: ["Docopt"],


### PR DESCRIPTION
Since we can't use a bundle to find the test data, we fall back on a relative path from the built executable.

This is a bit skanky, but it's a useable workaround, and better than not having the tests at all.