### PR TITLE
Fixed warnings caused by Swift 4 string changes.

### DIFF
--- a/DocoptTests/DocoptTestCaseParser.swift
+++ b/DocoptTests/DocoptTestCaseParser.swift
@@ -26,7 +26,7 @@ public struct DocoptTestCaseParser {
     
     private func removeComments(string: String) -> String {
         let removeCommentsRegEx = try! NSRegularExpression(pattern: "(?m)#.*$", options: [])
-        let fullRange: NSRange = NSMakeRange(0, string.characters.count)
+        let fullRange: NSRange = NSMakeRange(0, string.count)
         return removeCommentsRegEx.stringByReplacingMatches(in: string, options: [], range: fullRange, withTemplate: "")
     }
     

--- a/Sources/Docopt.swift
+++ b/Sources/Docopt.swift
@@ -177,7 +177,7 @@ open class Docopt : NSObject {
             let short = "-" + left[0..<1]
             let similar = options.filter {$0.short == short}
             var o: Option
-            left = left[1..<left.characters.count]
+            left = left[1..<left.count]
             
             if similar.count > 1 {
                 tokens.error.raise("\(short) is specified ambiguously \(similar.count) times")

--- a/Sources/String.swift
+++ b/Sources/String.swift
@@ -23,18 +23,18 @@ internal extension String {
     
     func findAll(_ regex: String, flags: NSRegularExpression.Options) -> [String] {
         let re = try! NSRegularExpression(pattern: regex, options: flags)
-        let all = NSMakeRange(0, self.characters.count)
+        let all = NSMakeRange(0, self.count)
         let matches = re.matches(in: self, options: [], range: all)
         return matches.map {self[$0.range(at: 1)].strip()}
     }
     
     func split() -> [String] {
-        return self.characters.split(whereSeparator: {$0 == " " || $0 == "\n"}).map(String.init)
+        return self.split(whereSeparator: {$0 == " " || $0 == "\n"}).map(String.init)
     }
     
     func split(_ regex: String) -> [String] {
         let re = try! NSRegularExpression(pattern: regex, options: .dotMatchesLineSeparators)
-        let all = NSMakeRange(0, self.characters.count)
+        let all = NSMakeRange(0, self.count)
         var result = [String]()
         let matches = re.matches(in: self, options: [], range: all)
         if matches.count > 0 {
@@ -52,7 +52,7 @@ internal extension String {
                     
                     result.append(self[range])
                     lastEnd = range.location + range.length
-                    if lastEnd == self.characters.count {
+                    if lastEnd == self.count {
                         // from python docs: If there are capturing groups in the separator and it matches at the start of the string,
                         // the result will start with an empty string. The same holds for the end of the string:
                         result.append("")
@@ -62,8 +62,8 @@ internal extension String {
                     lastEnd = match.range.location + match.range.length
                 }
             }
-            if lastEnd != self.characters.count {
-                result.append(self[lastEnd..<self.characters.count])
+            if lastEnd != self.count {
+                result.append(self[lastEnd..<self.count])
             }
             return result
         }
@@ -77,7 +77,7 @@ internal extension String {
     }
     
     subscript(range: Range<Int>) -> String {
-      return String(self[characters.index(startIndex, offsetBy: range.lowerBound)..<characters.index(startIndex, offsetBy: range.upperBound)])
+      return String(self[self.index(startIndex, offsetBy: range.lowerBound)..<self.index(startIndex, offsetBy: range.upperBound)])
     }
 
     subscript(range: NSRange) -> String {


### PR DESCRIPTION
Swift 4.0 deprecated `String.characters` in favour of directly accessing the string itself.