### PR TITLE
Fix warning with Swift 4.2 / Xcode 10

### DIFF
--- a/Sources/Docopt.swift
+++ b/Sources/Docopt.swift
@@ -18,7 +18,7 @@ open class Docopt : NSObject {
     fileprivate let optionsFirst: Bool
     fileprivate let arguments: [String]
     
-    @objc open static func parse(_ doc: String, argv: [String], help: Bool = false, version: String? = nil, optionsFirst: Bool = false) -> [String: AnyObject] {
+    @objc public static func parse(_ doc: String, argv: [String], help: Bool = false, version: String? = nil, optionsFirst: Bool = false) -> [String: AnyObject] {
         return Docopt(doc, argv: argv, help: help, version: version, optionsFirst: optionsFirst).result
     }
     


### PR DESCRIPTION
```Static declarations are implicitly 'final'; use 'public' instead of 'open'```